### PR TITLE
chore: create ENDPOINTS export and show example usage in speaker-application

### DIFF
--- a/src/app/(web)/speaker-application/page.tsx
+++ b/src/app/(web)/speaker-application/page.tsx
@@ -6,6 +6,11 @@ import StepPersonalInfo from "@/components/ui/SpeakerForm/StepPersonalInfo";
 import { SpeakerProps } from "@/types";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { usePostMutation } from "@/hooks/useApi";
+import { BUILDER_RESIDENCY } from "@/config/ENDPOINTS";
+import { toast } from "sonner";
+// import { yupResolver } from "@hookform/resolvers/yup";
+// import { speakerValidation } from "@/validations/speakerValidations";
 
 const steps = [
   "Personal Information",
@@ -16,7 +21,10 @@ const steps = [
 const SpeakerApplicationForm = () => {
   const router = useRouter();
   const [step, setStep] = useState(0);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { mutate, isPending } = usePostMutation(
+    BUILDER_RESIDENCY.CREATE,
+    "create_builder"
+  );
 
   // Initialize react-hook-form
   const {
@@ -26,6 +34,7 @@ const SpeakerApplicationForm = () => {
     watch,
     formState: { errors },
   } = useForm<SpeakerProps>({
+    // resolver: yupResolver(speakerValidation),
     defaultValues: {
       fullName: "",
       email: "",
@@ -52,15 +61,21 @@ const SpeakerApplicationForm = () => {
   const handleBack = () => setStep((prev) => prev - 1);
 
   const onSubmit = async (data: SpeakerProps) => {
-    try {
-      setIsSubmitting(true);
-      console.log("Form submitted with data:", data);
-      router.push("/success");
-    } catch (error) {
-      console.error("Error submitting form:", error);
-    } finally {
-      setIsSubmitting(false);
-    }
+    mutate(data, {
+      onSuccess: () => {
+        toast.success("Builder form submitted succefully");
+        router.push("/sucess");
+      },
+    });
+    // try {
+    //   setIsSubmitting(true);
+    //   console.log("Form submitted with data:", data);
+    //   router.push("/success");
+    // } catch (error) {
+    //   console.error("Error submitting form:", error);
+    // } finally {
+    //   setIsSubmitting(false);
+    // }
   };
 
   return (
@@ -111,7 +126,7 @@ const SpeakerApplicationForm = () => {
             formData={formData}
             onBack={handleBack}
             onNext={handleSubmit(onSubmit)}
-            isSubmitting={isSubmitting}
+            isSubmitting={isPending}
           />
         )}
       </div>

--- a/src/config/ENDPOINTS.ts
+++ b/src/config/ENDPOINTS.ts
@@ -1,0 +1,26 @@
+export const BUILDER_RESIDENCY = {
+  CREATE: "/builder",
+  GET_BY_ID: (id: string) => `/builder/${id}`,
+  GET_ALL: "/builder", // To get per page, we have </builder?page=1&limit=10>
+};
+
+export const CONFERENCE = {
+  CREATE: "/conference",
+  GET_BY_ID: (id: string) => `/conference/${id}`,
+  GET_ALL: "/conference", //to get per page ?page=1&limit=10&status=PENDING
+  UPDATE_STATUS: "/conference/status",
+};
+
+export const POPUP_CITY = {
+  CREATE: "/popup",
+  GET_BY_ID: (id: string) => `/popup/${id}`,
+  GET_ALL: "/popup", //to get per page ?page=1&limit=10&status=PENDING
+};
+
+export const SPEAKER = {
+  CREATE: "/speaker",
+  GET_BY_ID: (id: string) => `/speaker/${id}`,
+  GET_ALL: "/speaker", //to get per page ?page=1&limit=10&status=PENDING
+  UPDATE_STATUS: "/speaker/status",
+  DELETE: (id: string) => `/speaker/${id}`,
+};

--- a/src/validations/speakerValidations.ts
+++ b/src/validations/speakerValidations.ts
@@ -1,0 +1,24 @@
+import * as yup from "yup";
+
+export const speakerValidation = yup.object().shape({
+  fullName: yup.string().required(),
+  email: yup.string().email().required(),
+  gender: yup.string().required(),
+  whatsappNumber: yup.string().required(),
+  location: yup.string().required(),
+  githubProfile: yup.string().url().required(),
+  twitterProfile: yup.string().url().required(),
+  linkedinProfile: yup.string().url().required(),
+  portfolioUrl: yup.string().url().required(),
+  primaryRole: yup.string().required(),
+  backgroundAndSkills: yup.string().required(),
+  currentlyBuilding: yup.string().required(),
+  previousBuilderPrograms: yup.boolean().required(),
+  joinReason: yup.string().required(),
+  projectInterest: yup.string().required(),
+  openToCollaboration: yup.boolean().required(),
+  needsAccommodation: yup.boolean().required(),
+  dietaryAccessibilityNeeds: yup.string().required(),
+  referralSource: yup.string().required(),
+  joinOnlineCommunity: yup.boolean().required(),
+});


### PR DESCRIPTION
## 📌 Summary
Creates a consolidated endpoints output with example usage on how to use with yup validation

---

## ✅ Changes Made
- [x] created an `ENDPOINTS.ts` in the `_config` folder
- [x] created a `validations' folder to contain all yup validations
- [x] implemented an example in `speaker-application` for view

---

## 🔍 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/524dc174-8cab-4501-b970-1cdcc37e0428)

---

## 📋 Checklist
- [x] Code compiles and runs without errors
- [ ] Tests have been added/updated (if applicable)
- [x] I have manually tested the changes
- [ ] PR is linked to relevant issue/task/ticket (if applicable)

---

## 🔗 Related Issues / Tasks
> Mention linked issues, tasks, or user stories (e.g., `Closes #123`)

---

## 💬 Notes for Reviewers
The reusables in `useApi` are already built with axios and react-query(tanstack), so there is no need to initialise those again. We only need to use the hooks, pass the endpoints, and ensure the request body matches what is required
